### PR TITLE
Test token won't work for outlook if not encoded properly

### DIFF
--- a/docs/add-license-checks-to-office-and-sharepoint-add-ins.md
+++ b/docs/add-license-checks-to-office-and-sharepoint-add-ins.md
@@ -49,7 +49,31 @@ The Office application calling that URL would add the following query string to 
 
 The query string parameter _et_ specifies a base-64 and URL-encoded version of the add-in license token.
 
-For Outlook add-ins, the *et* query parameter string is only URL-encoded, and **not** base-64 encoded.
+For Outlook add-ins, the *et* query parameter string is only URL-encoded, and **not** base-64 encoded. Also note that you have to remove all the new lines of the token before encoding it. For example, the following token:
+
+```XML
+<r>
+  <t 
+    aid="WA907006056" 
+    pid="{4FB601F2-5469-4542-B9FC-B96345DC8B39}" 
+    cid="32F3E7FC559F4F49" 
+    did="{0672BAE9-B41B-48FE-87F1-7F4D3DD3F3B1}" 
+    ts="30" 
+    et="Trial" 
+    ad="2012-01-12T21:58:13Z" 
+    ed="2019-06-30T21:58:13Z" 
+    sd="2012-01-12T00:00:00Z"
+    test="true" 
+    te="2019-06-30T02:49:34Z" />
+  <d>VNNAnf36IrkyUVZlihQJNdUUZl/YFEfJOeldWBtd3IM=</d>
+</r>
+```
+
+Has to be converted into this:
+
+```
+<r> <t aid="WA907006056" pid="{4FB601F2-5469-4542-B9FC-B96345DC8B39}" cid="32F3E7FC559F4F49" did="{0672BAE9-B41B-48FE-87F1-7F4D3DD3F3B1}" ts="30" et="Trial" ad="2012-01-12T21:58:13Z" ed="2019-06-30T21:58:13Z" sd="2012-01-12T00:00:00Z" test="true" te="2019-06-30T02:49:34Z" /> <d>VNNAnf36IrkyUVZlihQJNdUUZl/YFEfJOeldWBtd3IM=</d> </r>
+```
 
 For example, the source location modified to include a test token for an Outlook add-in would look like this: 
 

--- a/docs/add-license-checks-to-office-and-sharepoint-add-ins.md
+++ b/docs/add-license-checks-to-office-and-sharepoint-add-ins.md
@@ -77,7 +77,7 @@ Has to be converted into this:
 
 For example, the source location modified to include a test token for an Outlook add-in would look like this: 
 
-  `https://myApp/index.htm?et=%3Cr%20v%3D%221%22%3E%3Ct%20aid%3D%22WA104108294%22%20pid%3D%22463eafac-c123-45fe-bd21-b1b120b4c12b%22%20cid%3D%223BEC2F1C0124D801%22%20did%3D%22CONTOSO.COM%22%20ts%3D%221%22%20et%3D%22Paid%22%20ad%3D%222013-08-29T21%3A38%3A14Z%22%20sd%3D%222013-09-17%22%20te%3D%222013-12-23T09%3A10%3A42Z%22%20test%3D%221%22%20ss%3D%220%22%20%2F%3E%3Cd%3E7uM9j2%2FYZJeZrrm2TLjXufQlwkAXkq2RqjowBP9fAjo%3D%3C%2Fd%3E%3C%2Fr%3E`
+  `https://myApp/index.htm?et=%3Cr%3E%20%3Ct%20aid%3D%22WA907006056%22%20pid%3D%22%7B4FB601F2-5469-4542-B9FC-B96345DC8B39%7D%22%20cid%3D%2232F3E7FC559F4F49%22%20did%3D%22%7B0672BAE9-B41B-48FE-87F1-7F4D3DD3F3B1%7D%22%20ts%3D%2230%22%20et%3D%22Trial%22%20ad%3D%222012-01-12T21%3A58%3A13Z%22%20ed%3D%222019-06-30T21%3A58%3A13Z%22%20sd%3D%222012-01-12T00%3A00%3A00Z%22%20test%3D%22true%22%20te%3D%222019-06-30T02%3A49%3A34Z%22%20%2F%3E%20%3Cd%3EVNNAnf36IrkyUVZlihQJNdUUZl%2FYFEfJOeldWBtd3IM%3D%3C%2Fd%3E%20%3C%2Fr%3E`
 
 > [!IMPORTANT]
 > For security reasons, if you are licensing your Office Add-in, we strongly recommended that you specify an HTTP Secure ( `https://`) URL for your add-in home page.

--- a/docs/add-license-checks-to-office-and-sharepoint-add-ins.md
+++ b/docs/add-license-checks-to-office-and-sharepoint-add-ins.md
@@ -25,7 +25,7 @@ For Outlook add-ins:
 
 - Create your test token.
 - Create a URL-encoded version of the add-in license token.
-- In the add-in manifest file, manually edit the appropriate [SourceLocation](http://dev.office.com/reference/add-ins/manifest/sourcelocation) element. Add the URL-encoded version of the license token to the source location URL as a query parameter named *et*  .
+- In the add-in manifest file, manually edit the appropriate [SourceLocation](http://dev.office.com/reference/add-ins/manifest/sourcelocation) element. Add the URL-encoded version of the license token to the source location URL as a query parameter named *et*.
 
     <br/>
 
@@ -69,13 +69,13 @@ For Outlook add-ins, the *et* query parameter string is only URL-encoded, and **
 </r>
 ```
 
-Has to be converted into this:
+Has to be converted to this:
 
 ```
 <r> <t aid="WA907006056" pid="{4FB601F2-5469-4542-B9FC-B96345DC8B39}" cid="32F3E7FC559F4F49" did="{0672BAE9-B41B-48FE-87F1-7F4D3DD3F3B1}" ts="30" et="Trial" ad="2012-01-12T21:58:13Z" ed="2019-06-30T21:58:13Z" sd="2012-01-12T00:00:00Z" test="true" te="2019-06-30T02:49:34Z" /> <d>VNNAnf36IrkyUVZlihQJNdUUZl/YFEfJOeldWBtd3IM=</d> </r>
 ```
 
-For example, the source location modified to include a test token for an Outlook add-in would look like this: 
+The source location modified to include a test token for an Outlook add-in would look like this: 
 
   `https://myApp/index.htm?et=%3Cr%3E%20%3Ct%20aid%3D%22WA907006056%22%20pid%3D%22%7B4FB601F2-5469-4542-B9FC-B96345DC8B39%7D%22%20cid%3D%2232F3E7FC559F4F49%22%20did%3D%22%7B0672BAE9-B41B-48FE-87F1-7F4D3DD3F3B1%7D%22%20ts%3D%2230%22%20et%3D%22Trial%22%20ad%3D%222012-01-12T21%3A58%3A13Z%22%20ed%3D%222019-06-30T21%3A58%3A13Z%22%20sd%3D%222012-01-12T00%3A00%3A00Z%22%20test%3D%22true%22%20te%3D%222019-06-30T02%3A49%3A34Z%22%20%2F%3E%20%3Cd%3EVNNAnf36IrkyUVZlihQJNdUUZl%2FYFEfJOeldWBtd3IM%3D%3C%2Fd%3E%20%3C%2Fr%3E`
 


### PR DESCRIPTION
If we don't remove all the new lines and encode the test toke, it will throw an error. This part is not clear in the documentation so I updated the doc to make it more clear.

I faced this issue and had to spend some time to figure out what's going on: https://stackoverflow.com/questions/54026756/cant-set-a-test-license-token-in-an-outlook-addin