### PR TITLE
Change China (PRC) to China

### DIFF
--- a/docs/prepare-localized-solutions.md
+++ b/docs/prepare-localized-solutions.md
@@ -60,7 +60,7 @@ The following table lists the submission languages that Microsoft AppSource is a
 |Dutch|nl-be|Belgium|
 |Dutch|nl-nl|The Netherlands|
 |Russian|ru-ru|Russia|
-|Chinese |zh-cn|China (PRC)|
+|Chinese |zh-cn|China|
 |Chinese |zh-hk|Chinese (Hong Kong SAR)|
 |Chinese |zh-tw|Taiwan|
 | Portuguese|pt-br|Brazil|


### PR DESCRIPTION
China (PRC) is an outdated name and should be changed to China